### PR TITLE
COBS wire encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,5 +37,6 @@ log = "0.4"
 
 [dev-dependencies]
 clap = { version = "3.1", features = ["derive"] }
+env_logger = "0.9.0"
 tokio = {version = "1.17.0", features = ["full"] }
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ tokio = {version = "1.17.0", features = ["io-util"] }
 tokio-serial = "5.4.1"
 futures = "0.3.21"
 cobs = "0.2"
+log = "0.4"
 
 [dev-dependencies]
 clap = { version = "3.1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ readme = "README.md"
 tokio = {version = "1.17.0", features = ["io-util"] }
 tokio-serial = "5.4.1"
 futures = "0.3.21"
+cobs = "0.2"
 
 [dev-dependencies]
 clap = { version = "3.1", features = ["derive"] }

--- a/examples/serial-echo.rs
+++ b/examples/serial-echo.rs
@@ -33,6 +33,9 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> tokio_serial::Result<()> {
+    // initiate logging
+    env_logger::init();
+
     let args = Args::parse();
     let mut buff = [0u8; 65535];
 
@@ -78,7 +81,7 @@ async fn main() -> tokio_serial::Result<()> {
                 tokio::time::sleep(Duration::from_secs_f64(timeout_duration)).await;
             };
 
-            let _out = tokio::select! {
+            tokio::select! {
                 res = port.read_msg(&mut buff) => {
                     let read = res?;
                     if read > 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,11 +238,15 @@ impl ZSerial {
                 .read_exact(std::slice::from_mut(&mut self.ser_buff[start_count]))
                 .await?;
 
+            log::trace!("Read {:02X?}", self.ser_buff[start_count]);
+
             if self.ser_buff[start_count] == SENTINEL {
                 break;
             }
             start_count += 1;
         }
+
+        log::trace!("Read COBS {:02X?}", &self.ser_buff[0..start_count]);
 
         // Deserialize
         self.formatter
@@ -267,6 +271,9 @@ impl ZSerial {
     pub async fn write(&mut self, buff: &[u8]) -> tokio_serial::Result<()> {
         // Serialize
         let written = self.formatter.serialize_into(buff, &mut self.ser_buff)?;
+
+        log::trace!("Wrote COBS {:02X?}", &self.ser_buff[0..written]);
+
         // Write
         self.serial.write_all(&self.ser_buff[0..written]).await?;
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ impl WireFormat {
     pub(crate) fn serialize_into(
         &mut self,
         src: &[u8],
-        mut dest: &mut [u8],
+        dest: &mut [u8],
     ) -> tokio_serial::Result<usize> {
         if src.len() > MAX_MTU {
             return Err(tokio_serial::Error::new(
@@ -122,14 +122,14 @@ impl WireFormat {
 
         // Copy into serialization buffer
         self.buff[0..LEN_FIELD_LEN].copy_from_slice(&size_bytes);
-        self.buff[LEN_FIELD_LEN..LEN_FIELD_LEN + src.len()].copy_from_slice(&src);
+        self.buff[LEN_FIELD_LEN..LEN_FIELD_LEN + src.len()].copy_from_slice(src);
         self.buff[LEN_FIELD_LEN + src.len()..LEN_FIELD_LEN + src.len() + CRC32_LEN]
             .copy_from_slice(&crc32);
 
         let total_len = LEN_FIELD_LEN + CRC32_LEN + src.len();
 
         // COBS encode
-        let written = cobs::encode_with_sentinel(&self.buff[0..total_len], &mut dest, SENTINEL);
+        let written = cobs::encode_with_sentinel(&self.buff[0..total_len], dest, SENTINEL);
 
         // Add sentinel byte, marks the end of a message
         dest[written + 1] = SENTINEL;
@@ -138,10 +138,10 @@ impl WireFormat {
 
     pub(crate) fn deserialize_into(
         &self,
-        mut src: &mut [u8],
+        src: &mut [u8],
         dst: &mut [u8],
     ) -> tokio_serial::Result<usize> {
-        let _size = cobs::decode_in_place_with_sentinel(&mut src, SENTINEL).map_err(|e| {
+        let _size = cobs::decode_in_place_with_sentinel(src, SENTINEL).map_err(|e| {
             tokio_serial::Error::new(
                 tokio_serial::ErrorKind::InvalidInput,
                 format!("Unable COBS decode: {e:?}"),

--- a/tests/crc.rs
+++ b/tests/crc.rs
@@ -17,6 +17,28 @@ use z_serial::CRC32;
 
 const MAX_ITERATIONS: usize = 4096;
 
+// FIXME: fix this test
+// #[test]
+// fn check_test_vectors() {
+//     // (:digest-test #a"" #h"00000000")
+//     // (:digest-test #a"a" #h"e8b7be43")
+//     // (:digest-test #a"abc" #h"352441c2")
+//     // (:digest-test #a"message digest" #h"20159d7f")
+//     // (:digest-test #a"abcdefghijklmnopqrstuvwxyz" #h"4c2750bd")
+//     // (:digest-test #a"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" #h"1fc2e6d2")
+//     // (:digest-test #a"12345678901234567890123456789012345678901234567890123456789012345678901234567890" #h"7ca94a72")
+
+//     let data: Vec<u8> = vec![];
+//     let crc = CRC32::default();
+
+//     let empty_crc = 0u32;
+//     assert_eq!(crc.compute_crc32(&data), empty_crc);
+
+//     let data: Vec<u8> = String::from("a").into_bytes();
+//     let a_crc = 0xe8b7be43;
+//     assert_eq!(crc.compute_crc32(&data), a_crc);
+// }
+
 #[test]
 fn check_same_crc() {
     let mut rng = rand::thread_rng();


### PR DESCRIPTION
This PR changes the wire encodings to [Consistent Overhead Byte Stuffing (COBS)](https://en.wikipedia.org/wiki/Consistent_Overhead_Byte_Stuffing)

So now on the wire the frame is:

```
/// +-+----+------------+--------+-+
/// |O|XXXX|ZZZZ....ZZZZ|CCCCCCCC|0|
/// +-+----+------------+--------+-+
/// |O| Len|   Data     |  CRC32 |C|
/// +-+-2--+----N-------+---4----+-+
```

At End-of-packet the `0x00` byte is used.